### PR TITLE
Whyred : sepolicy: add label /persist, /dsp

### DIFF
--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -29,3 +29,5 @@
 
 # Thermal
 /data/vendor/thermal(/.*)?                      u:object_r:thermal_data_file:s0
+# Persist
+/persist(/.*)?                                  u:object_r:tmp_file:s0


### PR DESCRIPTION
This addresses the mke2fs error set_selinux_xattr: No such file or directory searching for label
Note: this is a really hacky workaround. Try and fix this properly.