### PR TITLE
Whyred: sepolicy: add label /dsp

### DIFF
--- a/sepolicy/vendor/file.te
+++ b/sepolicy/vendor/file.te
@@ -3,3 +3,5 @@ type public_adsprpcd_file, file_type;
 type sysfs_fingerprint, fs_type, sysfs_type;
 type sysfs_touchpanel, fs_type, sysfs_type;
 type thermal_data_file, file_type, data_file_type;
+type tmp_file, file_type;
+


### PR DESCRIPTION
This addresses the mke2fs error set_selinux_xattr: No such file or directory searching for label
Note: this is a really hacky workaround. Try and fix this properly.